### PR TITLE
MP desync fix

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -33,6 +33,11 @@ script.on_init(function()
   end
 
   hookupYARM()
+  register_events()
+end)
+
+script.on_load(function()
+   register_events()
 end)
 
 script.on_configuration_changed(function(event)
@@ -45,31 +50,33 @@ script.on_configuration_changed(function(event)
   hookupYARM()
 end)
 
-script.on_event(defines.events.on_tick, function(event)
-  if event.tick % 600 == 0 then
-    for _, player in pairs(game.players) do
-      stats = {
-        {player.force.item_production_statistics, gauge_item_production_input, gauge_item_production_output},
-        {player.force.fluid_production_statistics, gauge_fluid_production_input, gauge_fluid_production_output},
-        {player.force.kill_count_statistics, gauge_kill_count_input, gauge_kill_count_output},
-        {player.force.entity_build_count_statistics, gauge_entity_build_count_input, gauge_entity_build_count_output},
-      }
+function register_events()
+   script.on_event(defines.events.on_tick, function(event)
+     if event.tick % 600 == 0 then
+       for _, player in pairs(game.players) do
+         stats = {
+           {player.force.item_production_statistics, gauge_item_production_input, gauge_item_production_output},
+           {player.force.fluid_production_statistics, gauge_fluid_production_input, gauge_fluid_production_output},
+           {player.force.kill_count_statistics, gauge_kill_count_input, gauge_kill_count_output},
+           {player.force.entity_build_count_statistics, gauge_entity_build_count_input, gauge_entity_build_count_output},
+         }
 
-      for _, stat in pairs(stats) do
-        for name, n in pairs(stat[1].input_counts) do
-          stat[2]:set(n, {player.force.name, name})
-        end
+         for _, stat in pairs(stats) do
+           for name, n in pairs(stat[1].input_counts) do
+             stat[2]:set(n, {player.force.name, name})
+           end
 
-        for name, n in pairs(stat[1].output_counts) do
-          stat[3]:set(n, {player.force.name, name})
-        end
-      end
+           for name, n in pairs(stat[1].output_counts) do
+             stat[3]:set(n, {player.force.name, name})
+           end
+         end
 
-      for name, n in pairs(player.force.items_launched) do
-        gauge_items_launched:set(n, {player.force.name, name})
-      end
-    end
+         for name, n in pairs(player.force.items_launched) do
+           gauge_items_launched:set(n, {player.force.name, name})
+         end
+       end
 
-    game.write_file("graftorio/game.prom", prometheus.collect(), false)
-  end
-end)
+       game.write_file("graftorio/game.prom", prometheus.collect(), false)
+     end
+   end)
+end


### PR DESCRIPTION
Fixes the desync issue (afex/graftorio#3) in MP by specifically registering the tick event in the init/load event.

Tested with the current Factorio experimental (0.17.9), but should work for 0.16 as well.